### PR TITLE
check for MARIAN in env

### DIFF
--- a/transformer-intro/run-me.sh
+++ b/transformer-intro/run-me.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MARIAN=../../build
+if [ -z ${MARIAN+x} ]; then MARIAN=../../build; fi
 if [ ! -e $MARIAN/marian ]; then
   echo "Marian is not found at '$MARIAN'. Please compile it first!"
   exit 1;

--- a/transformer-intro/run-me.sh
+++ b/transformer-intro/run-me.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ -z ${MARIAN+x} ]; then MARIAN=../../build; fi
+MARIAN=${MARIAN:-../../build}
 if [ ! -e $MARIAN/marian ]; then
   echo "Marian is not found at '$MARIAN'. Please compile it first!"
   exit 1;


### PR DESCRIPTION
This change allows the user to set `MARIAN` in their environment to override the current requirement that it be in `../../build`.